### PR TITLE
Marks singleton initialiser as private

### DIFF
--- a/Sources/SpotifyLogin.swift
+++ b/Sources/SpotifyLogin.swift
@@ -40,7 +40,7 @@ public class SpotifyLogin {
 
     internal var urlBuilder: URLBuilder?
 
-    init() {
+    private init() {
         self.session = KeychainService.loadSession()
     }
 


### PR DESCRIPTION
Assuming that we want consumers of the API to go through the shared instance I suggest marking the object's initialiser as `private`.

It's not a big problem in different modules at all but maybe still worth being explicit about it?