### PR TITLE
Reduce code duplication dispatching to main queue

### DIFF
--- a/Sources/Internal/Extensions/DispatchQueue.swift
+++ b/Sources/Internal/Extensions/DispatchQueue.swift
@@ -14,17 +14,9 @@
 
 import Foundation
 
-internal class SPDispatchQueue {
-    internal static func dispatchOnMain<T>(_ completion: @escaping (T?, Error?) -> Void,
-                                           _ param: T?, _ error: Error?) {
-        DispatchQueue.main.async {
-            completion(param, error)
-        }
-    }
-    internal static func dispatchOnMain<T>(_ completion: @escaping (T?) -> Void,
-                                           _ param: T?) {
-        DispatchQueue.main.async {
-            completion(param)
-        }
+internal extension DispatchQueue {
+
+    internal static func dispatchOnMain(_ closure: @autoclosure @escaping () -> Void) {
+        self.main.async(execute: closure)
     }
 }

--- a/Sources/Internal/Networking.swift
+++ b/Sources/Internal/Networking.swift
@@ -153,7 +153,10 @@ internal class Networking {
         task.resume()
     }
 
-    private class func dispatchOnMainQueue<T>(_ completion: (T?, Error?) -> Void, _ resultType: T?, _ error: Error?) {
-        completion(resultType, error)
+    private class func dispatchOnMainQueue<T>(_ completion: @escaping (T?, Error?) -> Void,
+                                              _ resultType: T?, _ error: Error?) {
+        DispatchQueue.main.async {
+            completion(resultType, error)
+        }
     }
 }

--- a/Sources/Internal/Networking.swift
+++ b/Sources/Internal/Networking.swift
@@ -61,11 +61,11 @@ internal class Networking {
                                               accessToken: response.accessToken,
                                               refreshToken: response.refreshToken,
                                               expirationDate: Date(timeIntervalSinceNow: response.expiresIn))
-                        SPDispatchQueue.dispatchOnMain(completion, session, nil)
+                        DispatchQueue.dispatchOnMain(completion(session, nil))
                     }
                 })
             } else {
-                SPDispatchQueue.dispatchOnMain(completion, nil, error)
+                DispatchQueue.dispatchOnMain(completion(nil, error))
             }
         }
     }
@@ -75,7 +75,7 @@ internal class Networking {
                                      clientSecret: String,
                                      completion: @escaping (Session?, Error?) -> Void) {
         guard let session = session, let refreshToken = session.refreshToken else {
-            SPDispatchQueue.dispatchOnMain(completion, nil, LoginError.noSession)
+            DispatchQueue.dispatchOnMain(completion(nil, LoginError.noSession))
             return
         }
         let requestBody = "grant_type=refresh_token&refresh_token=\(refreshToken)"
@@ -88,9 +88,9 @@ internal class Networking {
                                       accessToken: response.accessToken,
                                       refreshToken: session.refreshToken,
                                       expirationDate: Date(timeIntervalSinceNow: response.expiresIn))
-                SPDispatchQueue.dispatchOnMain(completion, session, nil)
+                DispatchQueue.dispatchOnMain(completion(session, nil))
             } else {
-                SPDispatchQueue.dispatchOnMain(completion, nil, error)
+                DispatchQueue.dispatchOnMain(completion(nil, error))
             }
         }
     }
@@ -111,9 +111,9 @@ internal class Networking {
                                               completionHandler: { (data, _, error) in
             if let data = data, error == nil {
                 let profileResponse = try? JSONDecoder().decode(ProfileEndpointResponse.self, from: data)
-                SPDispatchQueue.dispatchOnMain(completion, profileResponse?.identifier)
+                DispatchQueue.dispatchOnMain(completion(profileResponse?.identifier))
             } else {
-                SPDispatchQueue.dispatchOnMain(completion, nil)
+                DispatchQueue.dispatchOnMain(completion(nil))
             }
         })
         task.resume()
@@ -125,8 +125,8 @@ internal class Networking {
                                     completion: @escaping (TokenEndpointResponse?, Error?) -> Void) {
         guard let authString = "\(clientID):\(clientSecret)"
             .data(using: .ascii)?.base64EncodedString(options: .endLineWithLineFeed) else {
-            SPDispatchQueue.dispatchOnMain(completion, nil, LoginError.configurationMissing)
-            return
+                DispatchQueue.dispatchOnMain(completion(nil, LoginError.configurationMissing))
+                return
         }
         let endpoint = URL(string: apiTokenEndpointURL)!
         var urlRequest = URLRequest(url: endpoint)
@@ -141,9 +141,9 @@ internal class Networking {
                                               completionHandler: { (data, _, error) in
             if let data = data,
                 let authResponse = try? JSONDecoder().decode(TokenEndpointResponse.self, from: data), error == nil {
-                SPDispatchQueue.dispatchOnMain(completion, authResponse, error)
+                DispatchQueue.dispatchOnMain(completion(authResponse, error))
             } else {
-                SPDispatchQueue.dispatchOnMain(completion, nil, error)
+                DispatchQueue.dispatchOnMain(completion(nil, error))
             }
         })
         task.resume()

--- a/Sources/Internal/SPDispatchQueue.swift
+++ b/Sources/Internal/SPDispatchQueue.swift
@@ -1,0 +1,30 @@
+// Copyright (c) 2017 Spotify AB.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+internal class SPDispatchQueue {
+    internal static func dispatchOnMain<T>(_ completion: @escaping (T?, Error?) -> Void,
+                                           _ param: T?, _ error: Error?) {
+        DispatchQueue.main.async {
+            completion(param, error)
+        }
+    }
+    internal static func dispatchOnMain<T>(_ completion: @escaping (T?) -> Void,
+                                           _ param: T?) {
+        DispatchQueue.main.async {
+            completion(param)
+        }
+    }
+}

--- a/SpotifyLogin.podspec
+++ b/SpotifyLogin.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '9.0'
   s.requires_arc = true
 
-  s.source_files = "SpotifyLogin", "Sources", "Sources/Internal"
+  s.source_files = "SpotifyLogin", "Sources", "Sources/Internal", "Sources/Internal/Extensions"
   s.resources = "SpotifyLogin/Resources/*.*"
 
   # s.public_header_files = 'Pod/Classes/**/*.h'

--- a/SpotifyLogin.xcodeproj/project.pbxproj
+++ b/SpotifyLogin.xcodeproj/project.pbxproj
@@ -21,7 +21,7 @@
 		3479D2A31EC1B00B00FF4EE2 /* SpotifyLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3479D2A21EC1B00B00FF4EE2 /* SpotifyLogin.swift */; };
 		3479D2A51EC1B50900FF4EE2 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3479D2A41EC1B50900FF4EE2 /* Constants.swift */; };
 		34AB98631F2DEDD300FE5F3B /* SafariDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AB98621F2DEDD300FE5F3B /* SafariDelegate.swift */; };
-		BD9B70331FF39F2000E45ECD /* SPDispatchQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9B70321FF39F2000E45ECD /* SPDispatchQueue.swift */; };
+		BD9B70331FF39F2000E45ECD /* DispatchQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9B70321FF39F2000E45ECD /* DispatchQueue.swift */; };
 		BEF4FC611EC1AE810082945B /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEF4FC601EC1AE810082945B /* Session.swift */; };
 		E19201361F8CD6D100DA1AB1 /* SessionLocalStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19201351F8CD66B00DA1AB1 /* SessionLocalStorage.swift */; };
 /* End PBXBuildFile section */
@@ -54,7 +54,7 @@
 		3479D2A21EC1B00B00FF4EE2 /* SpotifyLogin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SpotifyLogin.swift; path = ../Sources/SpotifyLogin.swift; sourceTree = "<group>"; };
 		3479D2A41EC1B50900FF4EE2 /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		34AB98621F2DEDD300FE5F3B /* SafariDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariDelegate.swift; sourceTree = "<group>"; };
-		BD9B70321FF39F2000E45ECD /* SPDispatchQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPDispatchQueue.swift; sourceTree = "<group>"; };
+		BD9B70321FF39F2000E45ECD /* DispatchQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchQueue.swift; sourceTree = "<group>"; };
 		BEF4FC601EC1AE810082945B /* Session.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Session.swift; sourceTree = "<group>"; };
 		E19201351F8CD66B00DA1AB1 /* SessionLocalStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLocalStorage.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -91,13 +91,13 @@
 		3432C7331F2DCF250001E70D /* Internal */ = {
 			isa = PBXGroup;
 			children = (
+				BDAD27791FF4FB0C009C5D27 /* Extensions */,
 				3479D2A41EC1B50900FF4EE2 /* Constants.swift */,
 				34057DB11F2D27B8001D65AA /* Networking.swift */,
 				BEF4FC601EC1AE810082945B /* Session.swift */,
 				E19201351F8CD66B00DA1AB1 /* SessionLocalStorage.swift */,
 				3432C7311F2DCBF30001E70D /* URLBuilder.swift */,
 				34AB98621F2DEDD300FE5F3B /* SafariDelegate.swift */,
-				BD9B70321FF39F2000E45ECD /* SPDispatchQueue.swift */,
 			);
 			name = Internal;
 			path = ../Sources/Internal;
@@ -143,6 +143,14 @@
 				3479D2951EC1ADEE00FF4EE2 /* Info.plist */,
 			);
 			path = SpotifyLoginTests;
+			sourceTree = "<group>";
+		};
+		BDAD27791FF4FB0C009C5D27 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				BD9B70321FF39F2000E45ECD /* DispatchQueue.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -283,7 +291,7 @@
 				34AB98631F2DEDD300FE5F3B /* SafariDelegate.swift in Sources */,
 				3432C7301F2DCBDE0001E70D /* Scope.swift in Sources */,
 				3432C7321F2DCBF30001E70D /* URLBuilder.swift in Sources */,
-				BD9B70331FF39F2000E45ECD /* SPDispatchQueue.swift in Sources */,
+				BD9B70331FF39F2000E45ECD /* DispatchQueue.swift in Sources */,
 				BEF4FC611EC1AE810082945B /* Session.swift in Sources */,
 				34057DB21F2D27B8001D65AA /* Networking.swift in Sources */,
 				344B226B1F30D530008D4CAF /* SpotifyLoginPresenter.swift in Sources */,

--- a/SpotifyLogin.xcodeproj/project.pbxproj
+++ b/SpotifyLogin.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		3479D2A31EC1B00B00FF4EE2 /* SpotifyLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3479D2A21EC1B00B00FF4EE2 /* SpotifyLogin.swift */; };
 		3479D2A51EC1B50900FF4EE2 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3479D2A41EC1B50900FF4EE2 /* Constants.swift */; };
 		34AB98631F2DEDD300FE5F3B /* SafariDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AB98621F2DEDD300FE5F3B /* SafariDelegate.swift */; };
+		BD9B70331FF39F2000E45ECD /* SPDispatchQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9B70321FF39F2000E45ECD /* SPDispatchQueue.swift */; };
 		BEF4FC611EC1AE810082945B /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEF4FC601EC1AE810082945B /* Session.swift */; };
 		E19201361F8CD6D100DA1AB1 /* SessionLocalStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19201351F8CD66B00DA1AB1 /* SessionLocalStorage.swift */; };
 /* End PBXBuildFile section */
@@ -53,6 +54,7 @@
 		3479D2A21EC1B00B00FF4EE2 /* SpotifyLogin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SpotifyLogin.swift; path = ../Sources/SpotifyLogin.swift; sourceTree = "<group>"; };
 		3479D2A41EC1B50900FF4EE2 /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		34AB98621F2DEDD300FE5F3B /* SafariDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariDelegate.swift; sourceTree = "<group>"; };
+		BD9B70321FF39F2000E45ECD /* SPDispatchQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPDispatchQueue.swift; sourceTree = "<group>"; };
 		BEF4FC601EC1AE810082945B /* Session.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Session.swift; sourceTree = "<group>"; };
 		E19201351F8CD66B00DA1AB1 /* SessionLocalStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLocalStorage.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -95,6 +97,7 @@
 				E19201351F8CD66B00DA1AB1 /* SessionLocalStorage.swift */,
 				3432C7311F2DCBF30001E70D /* URLBuilder.swift */,
 				34AB98621F2DEDD300FE5F3B /* SafariDelegate.swift */,
+				BD9B70321FF39F2000E45ECD /* SPDispatchQueue.swift */,
 			);
 			name = Internal;
 			path = ../Sources/Internal;
@@ -280,6 +283,7 @@
 				34AB98631F2DEDD300FE5F3B /* SafariDelegate.swift in Sources */,
 				3432C7301F2DCBDE0001E70D /* Scope.swift in Sources */,
 				3432C7321F2DCBF30001E70D /* URLBuilder.swift in Sources */,
+				BD9B70331FF39F2000E45ECD /* SPDispatchQueue.swift in Sources */,
 				BEF4FC611EC1AE810082945B /* Session.swift in Sources */,
 				34057DB21F2D27B8001D65AA /* Networking.swift in Sources */,
 				344B226B1F30D530008D4CAF /* SpotifyLoginPresenter.swift in Sources */,


### PR DESCRIPTION
This PR reduces duplicated calls when dispatching completion handlers back to the main queue.

We can now pass a generic result type and en error object that is used in the majority of cases to a private helper function that takes over the job of calling the GCP API.