### PR TITLE
Fix weak SafariDelegate reference in SpotifyLoginPresenter

### DIFF
--- a/Sources/SpotifyLoginPresenter.swift
+++ b/Sources/SpotifyLoginPresenter.swift
@@ -36,7 +36,8 @@ public class SpotifyLoginPresenter {
             viewController.definesPresentationContext = true
             let safariViewController: SFSafariViewController = SFSafariViewController(url: webAuthenticationURL)
             safariViewController.modalPresentationStyle = .pageSheet
-            safariViewController.delegate = SafariDelegate()
+            let delegate = SafariDelegate()
+            safariViewController.delegate = delegate
             viewController.present(safariViewController, animated: true, completion: nil)
             SpotifyLogin.shared.safariVC = safariViewController
         } else {


### PR DESCRIPTION
Xcode throws the Swift compiler warning: `Instance will be immediately deallocated because property 'delegate' is 'weak'` when using SpotifyLogin. 

By switching the delegate to a strong reference, it stops throwing the compiler warning.